### PR TITLE
Fixed the iframe issue with shadow root

### DIFF
--- a/index.html
+++ b/index.html
@@ -64,9 +64,7 @@
       <h1 class="b336centered" id="x001project-title"></h1>
       <div id="x001editor-wrap">
         <div id="x001editor"></div>
-        <div id="x001preview">
-          <iframe id="x001thepreview" frameborder="0"></iframe>
-        </div>
+        <div id="x001preview"></div>
       </div>
       <div id="x001code-underline">
         <div id="x001button-wrapper">

--- a/script.js
+++ b/script.js
@@ -109,7 +109,10 @@ function openNav() {
   $('#x001nav-links').style.animationFillMode = 'forwards';
 }
 function restart() {
-  $('#x001preview #x001thepreview').srcdoc = e.getOption('value');
+  if (!$('#x001preview').shadowRoot) {
+    $('#x001preview').attachShadow({ mode: 'open' });
+  }
+  $('#x001preview').shadowRoot.innerHTML = e.getOption('value');
   if (w) {
     w.document.open();
     w.document.write(e.getOption('value'));

--- a/style.css
+++ b/style.css
@@ -44,11 +44,6 @@
 } */
 /* if you still want that just prepend some styles to the srcdoc */
 
-#x001thepreview {
-  width: 100%;
-  height: 100%;
-}
-
 #x001code-underline {
   position: absolute;
   left: 5%;


### PR DESCRIPTION
JS won't work in the preview on the right still, but CSS will work great. But the JS will work fine when you deploy or open, so I think it's okay! (Shadow root will work fine on KA)

After all, since I fixed the live reloading on the live preview, you could even just split-screen your code editor with that and have a perfectly good experience.